### PR TITLE
Fixed the broken link to API key in the plugin doc

### DIFF
--- a/config/virustotal.spc
+++ b/config/virustotal.spc
@@ -2,6 +2,6 @@ connection "virustotal" {
   plugin = "virustotal"
 
   # Sign up at VirusTotal for your free API key
-  # https://support.virustotal.com/hc/en-us/articles/115002100149-API
+  # https://docs.virustotal.com/docs/please-give-me-an-api-key
   # api_key = "beec40da46647b5e31d5377af470c0c525fd4185fb14ed2d0b38a038718ae3bf"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ steampipe plugin install virustotal
 
 | Item        | Description                                                                                                               |
 | :---------- | :------------------------------------------------------------------------------------------------------------------------ |
-| Credentials | VirusTotal requires a [free API key](https://support.virustotal.com/hc/en-us/articles/115002100149-API) for all requests. |
+| Credentials | VirusTotal requires a [free API key](https://docs.virustotal.com/docs/please-give-me-an-api-key) for all requests. |
 | Radius      | Each connection represents a single VirusTotal account.                                                                   |
 
 ### Configuration


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
